### PR TITLE
Split sound into keydown and keyup portions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,12 @@ flume = "0.10.9"
 
 [target.'cfg(windows)'.dependencies]
 thread-priority = "0.2.4"
+
+[[example]]
+name = "trimmer_splitter"
+path = "examples/trimmer_splitter.rs"
+
+[dev-dependencies]
+anyhow = "1.0.44"
+wav = "1.0.0"
+

--- a/examples/trimmer_splitter.rs
+++ b/examples/trimmer_splitter.rs
@@ -1,0 +1,103 @@
+use anyhow::Result;
+use rodio::{source::Source, Decoder};
+use std::io::BufReader;
+use std::path::Path;
+use std::{env, fs::File};
+use wav::WAV_FORMAT_PCM;
+
+struct SoundFile {
+    data: Vec<i16>,
+    sample_rate: usize,
+    num_channels: usize,
+}
+
+impl SoundFile {
+    fn from_ogg(path: &Path) -> Result<Self> {
+        let ogg_file = BufReader::new(File::open(path).unwrap());
+        let decoded_file = Decoder::new(ogg_file).unwrap();
+        let sample_rate = decoded_file.sample_rate() as usize;
+        let num_channels = decoded_file.channels() as usize;
+        let data: Vec<i16> = decoded_file.collect();
+        Ok(SoundFile {
+            data,
+            sample_rate,
+            num_channels,
+        })
+    }
+
+    fn split(self) -> (SoundFile, SoundFile) {
+        let len = self.data.len();
+        (
+            SoundFile {
+                data: self.data[..len / 2].to_vec(),
+                sample_rate: self.sample_rate,
+                num_channels: self.num_channels,
+            },
+            SoundFile {
+                data: self.data[len / 2..].to_vec(),
+                sample_rate: self.sample_rate,
+                num_channels: self.num_channels,
+            },
+        )
+    }
+
+    fn trim(&mut self) {
+        let mut intensities = self
+            .data
+            .chunks(20)
+            .map(|x| x.iter().map(|y| y.abs() as isize).sum());
+        let mut max_val = 0;
+        for x in intensities.clone() {
+            if x > max_val {
+                max_val = x;
+            }
+        }
+        let start_index = intensities
+            .position(|x| x > max_val / 10)
+            .expect("No start_index");
+        // Back up the starting index chunk by one for a conservative start
+        // and then map back to sample coordinates
+        let start_index = (start_index.saturating_sub(5)) * 20;
+        self.data.rotate_left(start_index);
+        self.data.truncate(self.data.len() - start_index);
+    }
+
+    fn to_wav(&self, path: &Path) -> Result<()> {
+        let data = wav::bit_depth::BitDepth::Sixteen(self.data.clone());
+        let mut file = File::create(path)?;
+        wav::write(
+            wav::Header::new(WAV_FORMAT_PCM, 2, self.sample_rate as u32, 16),
+            &data,
+            &mut file,
+        )
+        .map_err(|x| x.into())
+    }
+}
+
+fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        Err(anyhow::anyhow!("Need a path to an ogg file"))
+    } else {
+        let path = Path::new(&args[1]);
+        assert!(
+            path.is_dir() && path.join("config.json").is_file(),
+            "Need a path to a directory containing config.json"
+        );
+        let dir = std::fs::read_dir(path)?;
+        for file in dir {
+            let file = file.unwrap().path();
+            if let Some(extension) = file.extension() {
+                if extension == "ogg" {
+                    let s = SoundFile::from_ogg(&file)?;
+                    let (mut s1, mut s2) = s.split();
+                    s1.trim();
+                    s2.trim();
+                    s1.to_wav(&file.with_extension("wav"))?;
+                    s2.to_wav(&file.with_extension("up.wav"))?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,21 @@ fn callback(event: Event, json_file: serde_json::Map<std::string::String, serde_
                 .lock()
                 .expect("Can't open key_depressed set for removal")
                 .remove(&key_code.unwrap_or(0));
-            // println!("In the future, this'll trigger the keyup sound")
+            let args: Vec<String> = env::args().collect();
+            let directory = args[1].clone();
+
+            let mut dest = match key_code {
+                Some(code) => json_file["defines"][&code.to_string()].to_string(),
+                None => {
+                    println!("Unmapped key: {:?}", key); // for debugging
+                    let default_key = 30; // keycode for 'a'
+                    json_file["defines"][&default_key.to_string()].to_string()
+                }
+            };
+            dest.remove(0);
+            dest.remove(dest.len() - 1);
+            let dest = std::path::Path::new(&dest).with_extension("up.wav");
+            sound::play_sound(format!("{}/{}", directory, &dest.to_str().unwrap()));
         }
         _ => (),
     }


### PR DESCRIPTION
I wanted to put a draft PR up since this has bigger changes in functionality, and will require pre-processing of soundpacks in order to support the new format.

# What this PR does:
* Introduces a new utility script to iterate through a soundpack, analyze the ogg files, split them into the key-up and key-down portions, trim silent whitespace off the front edge (to further reduce delay), and then save out as wav files.
* Modify the main `rustyvibes` driver to play the appropriate key down and key up sounds at the right time.

# Gaps/deficiencies in this current PR
* Rust ogg encoder crates are few and far between, so here for simplicity I'm writing out to wav instead.
* I need to clean up and improve the conversion script to also modify the `config.json` as well, and delete the original ogg files.
* The usage of `up.wav` extension is a bit of a hack, but avoids me from having to do more major surgery to the config schema.

I'd like to know if this is a direction I should keep pursuing before continuing though. So what do you think?

In trying it out, I think it's pretty flippin' sweet to hear an accurate key down and key up sound at the right times. Really makes it feel realistic. But that's just my $0.02.