### PR TITLE
Volume support and better command parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ libc = "0.2.66"
 rodio_wav_fix = "0.15.0"
 once_cell = "1.8.0"
 flume = "0.10.9"
+clap = { version = "4.0.27", features = ["derive"] }
 
 [target.'cfg(windows)'.dependencies]
 thread-priority = "0.2.4"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,21 @@
+
+use clap::Parser;
+
+
+#[derive(Debug, Parser)]
+#[clap(
+    name = "rustyvibes",
+    version,
+    about = "A Rust CLI that makes mechanical keyboard sound effects on every key press"
+)]
+#[clap(propagate_version = true)]
+pub struct ArgParser {
+    
+    /// The path of the soundpack
+    pub soundpack: String,
+
+    /// The volume to be set. 
+    /// Default: 100
+    #[arg(short, long)]
+    pub volume: Option<u16>
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 mod keycode;
 mod play_sound;
+mod args;
 mod start;
 
-use std::env;
+use clap::Parser;
+use crate::args::ArgParser;
 
 const ASCII_ART: &str =
     r#"
@@ -13,28 +15,12 @@ const ASCII_ART: &str =
 ██   ██  ██████  ███████    ██       ██      ████   ██ ██████  ███████ ███████
 "#;
 
-fn help() {
-    println!("{}
-Usage: rustyvibes <soundpack_path>", ASCII_ART);
-}
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() == 1 {
-        help();
-    } else {
-        match args[1].as_str() {
-            "--help" => {
-                help();
-            }
-            "--version" => {
-                println!("{}", ASCII_ART);
-                println!("You are on version {}", env!("CARGO_PKG_VERSION"));
-            }
-            _ => {
-                println!("{}", ASCII_ART);
-                start::rustyvibes::start_rustyvibes(args[1].clone());
-            }
-        }
-    }
+    println!("{}", ASCII_ART);
+    let a = ArgParser::parse();
+    let soundpack = a.soundpack;
+    let vol = a.volume.or(Some(100)).unwrap();
+
+    start::rustyvibes::start_rustyvibes(soundpack, vol);
 }

--- a/src/start.rs
+++ b/src/start.rs
@@ -25,10 +25,10 @@ pub mod rustyvibes {
             let soundpack_config = &format!("{}/config.json", directory)[..];
             self.value = Some(initialize_json(soundpack_config).unwrap());
         }
-        pub fn event_handler(self: &Self, event: Event, directory: String) {
+        pub fn event_handler(self: &Self, event: Event, directory: String, vol: u16) {
             match &self.value {
                 Some(value) => {
-                    callback(event, value.clone(), directory);
+                    callback(event, value.clone(), directory, vol);
                 }
                 None => {
                     println!("JSON wasn't initialized");
@@ -37,7 +37,7 @@ pub mod rustyvibes {
         }
     }
     
-    pub fn start_rustyvibes(args: String) {
+    pub fn start_rustyvibes(args: String, vol: u16) {
         {
             #[cfg(any(target_os = "macos", target_os = "linux"))]
             unsafe {
@@ -61,7 +61,7 @@ pub mod rustyvibes {
         println!("Rustyvibes is running");
 
         let event_handler = move |event: Event| {
-            json_file.event_handler(event, args.clone());
+            json_file.event_handler(event, args.clone(), vol);
         };
 
         if let Err(error) = listen(event_handler) {
@@ -75,7 +75,7 @@ pub mod rustyvibes {
     
     static KEY_DEPRESSED: Lazy<Mutex<HashSet<i32>>> = Lazy::new(|| Mutex::new(HashSet::new()));
     
-    fn callback(event: Event, json_file: serde_json::Map<std::string::String, serde_json::Value>, directory: String) {
+    fn callback(event: Event, json_file: serde_json::Map<std::string::String, serde_json::Value>, directory: String, vol: u16) {
         match event.event_type {
             rdev::EventType::KeyPress(key) => {
                 let key_code = key_code::code_from_key(key);
@@ -94,7 +94,7 @@ pub mod rustyvibes {
                     };
                     dest.remove(0);
                     dest.remove(dest.len() - 1);
-                    sound::play_sound(format!("{}/{}", directory, dest));
+                    sound::play_sound(format!("{}/{}", directory, dest), vol);
                 }
             }
             rdev::EventType::KeyRelease(key) => {


### PR DESCRIPTION
# Changes

- `clap` library is used to parse commands instead of manually parsing.
- volume support is added by sending the filename and the volume value to the worker.