### PR TITLE
Fix a typo in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You Will Need To install Advanced Linux Sound Architecture [ ALSA ]
 
 Ubuntu / debian
 ```
-sudo apt-get to install alsa-tools
+sudo apt-get install alsa-tools
 ```
 
 Fedora


### PR DESCRIPTION
Fixing a small typo at README.md, regarding the installation command of ALSA on a Debian-based Linux distribution.